### PR TITLE
refactor: switch from List to Set for EnabledEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5 (2024-11-20)
+
+FIXES:
+
+* Use Sets for webhook endpoint enabled events
+
 ## 0.0.4 (2024-11-19)
 
 FIXES:

--- a/docs/resources/webhook_endpoint.md
+++ b/docs/resources/webhook_endpoint.md
@@ -34,7 +34,7 @@ resource "stripe_webhook_endpoint" "example" {
 
 ### Required
 
-- `enabled_events` (List of String) The list of events to enable for this endpoint. `['*']` indicates that all events are enabled, except those that require explicit selection.
+- `enabled_events` (Set of String) The list of events to enable for this endpoint. `['*']` indicates that all events are enabled, except those that require explicit selection.
 - `url` (String) The URL of the webhook endpoint.
 
 ### Optional

--- a/internal/provider/resource_webhook_endpoint_test.go
+++ b/internal/provider/resource_webhook_endpoint_test.go
@@ -117,7 +117,7 @@ func TestBuildCreateParamsWebhookEndpointResource(t *testing.T) {
 		{
 			name: "all values provided",
 			plan: WebhookEndpointResourceModel{
-				EnabledEvents: testListValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
+				EnabledEvents: testSetValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
 				URL:           types.StringValue("https://example.com"),
 				Description:   types.StringValue("Test description"),
 				Metadata:      testMapValue(t, types.StringType, map[string]interface{}{"key": types.StringValue("value")}),
@@ -193,10 +193,10 @@ func TestBuildUpdateParamsWebhookEndpointResource(t *testing.T) {
 		{
 			name: "update enabled events",
 			state: WebhookEndpointResourceModel{
-				EnabledEvents: testListValue(t, types.StringType, []attr.Value{types.StringValue("event1")}),
+				EnabledEvents: testSetValue(t, types.StringType, []attr.Value{types.StringValue("event1")}),
 			},
 			plan: WebhookEndpointResourceModel{
-				EnabledEvents: testListValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
+				EnabledEvents: testSetValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
 			},
 			expected: stripe.WebhookEndpointParams{
 				EnabledEvents: stripe.StringSlice([]string{"event1", "event2"}),
@@ -294,7 +294,7 @@ func TestPopulateModelWebhookEndpointResource(t *testing.T) {
 				Application:   types.StringValue("app_id"),
 				Description:   types.StringValue("Test description"),
 				Disabled:      types.BoolValue(false),
-				EnabledEvents: testListValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
+				EnabledEvents: testSetValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
 				Metadata:      testMapValue(t, types.StringType, map[string]interface{}{"key": types.StringValue("value")}),
 				URL:           types.StringValue("https://example.com"),
 			},
@@ -316,7 +316,7 @@ func TestPopulateModelWebhookEndpointResource(t *testing.T) {
 				Application:   types.StringValue("app_id"),
 				Description:   types.StringValue("Test description"),
 				Disabled:      types.BoolValue(false),
-				EnabledEvents: testListValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
+				EnabledEvents: testSetValue(t, types.StringType, []attr.Value{types.StringValue("event1"), types.StringValue("event2")}),
 				Metadata:      types.MapNull(types.StringType),
 				URL:           types.StringValue("https://example.com"),
 			},
@@ -338,7 +338,7 @@ func TestPopulateModelWebhookEndpointResource(t *testing.T) {
 				Application:   types.StringValue("app_id"),
 				Description:   types.StringValue("Test description"),
 				Disabled:      types.BoolValue(false),
-				EnabledEvents: testListValue(t, types.StringType, []attr.Value{}),
+				EnabledEvents: testSetValue(t, types.StringType, []attr.Value{}),
 				Metadata:      testMapValue(t, types.StringType, map[string]interface{}{"key": types.StringValue("value")}),
 				URL:           types.StringValue("https://example.com"),
 			},
@@ -360,7 +360,7 @@ func TestPopulateModelWebhookEndpointResource(t *testing.T) {
 				Application:   types.StringNull(),
 				Description:   types.StringNull(),
 				Disabled:      types.BoolValue(false),
-				EnabledEvents: testListValue(t, types.StringType, []attr.Value{}),
+				EnabledEvents: testSetValue(t, types.StringType, []attr.Value{}),
 				Metadata:      types.MapNull(types.StringType),
 				URL:           types.StringValue("https://example.com"),
 			},

--- a/internal/provider/test_utils.go
+++ b/internal/provider/test_utils.go
@@ -18,6 +18,14 @@ func testListValue(t *testing.T, elemType attr.Type, vals interface{}) types.Lis
 	return lv
 }
 
+func testSetValue(t *testing.T, elemType attr.Type, vals interface{}) types.Set {
+	lv, diags := types.SetValueFrom(context.Background(), elemType, vals)
+	if diags.HasError() {
+		t.Fatalf("failed to construct list value: %s", diags)
+	}
+	return lv
+}
+
 func testMapValue(t *testing.T, elemType attr.Type, vals map[string]interface{}) types.Map {
 	mv, diags := types.MapValueFrom(context.Background(), elemType, vals)
 	if diags.HasError() {

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -29,6 +29,25 @@ func convertListToStringPtrs(tflist types.List) []*string {
 	return strings
 }
 
+func convertSetToStringPtrs(set types.Set) []*string {
+	if set.IsUnknown() || set.IsNull() {
+		return nil
+	}
+
+	var strings []*string
+	for _, element := range set.Elements() {
+		if element.IsNull() {
+			strings = append(strings, nil)
+		} else {
+			if str, ok := element.(types.String); ok {
+				s := str.ValueString()
+				strings = append(strings, &s)
+			}
+		}
+	}
+	return strings
+}
+
 func Float64NullIfEmpty(input float64) types.Float64 {
 	if input == 0 {
 		return types.Float64Null()


### PR DESCRIPTION
Updated WebhookEndpointResourceModel to use types.Set for EnabledEvents instead of types.List. This change ensures unique values and aligns with the schema requirements. Adjusted related helper functions and tests accordingly.